### PR TITLE
Add heartbeat to solve stale tcp issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Usage:
 
 Flags:
   -a, --aggregate-interval int         Interval at which stats are aggregated (default 15)
+  -b, --beat-interval int              Heartbeat frequency (seconds) (default 30)
   -c, --config-file string             Config file location for server
   -C, --cors-allow string              Sets the 'Access-Control-Allow-Origin' header (default "*")
   -H, --http-listen-address string     Http listen address (default "127.0.0.1:8080")
@@ -50,7 +51,8 @@ Flags:
   "token": "secret",
   "poll-interval": 60,
   "aggregate-interval": 15,
-  "retention": 1
+  "beat-interval": 30,
+  "retention": 12
 }
 ```
 
@@ -150,8 +152,6 @@ The TCP api used to communicate between the pulse server and a relay is simple a
 Contributions to the pulse project are welcome and encouraged. Pulse is a [Nanobox](https://nanobox.io) project and contributions should follow the [Nanobox Contribution Process & Guidelines](https://docs.nanobox.io/contributing/).
 
 #### TODO
-- Ensure conn.Read() can handle network partitions
-- Tests
 
 ## Licence
 

--- a/api/api.go
+++ b/api/api.go
@@ -119,7 +119,7 @@ func writeBody(v interface{}, rw http.ResponseWriter, status int, req *http.Requ
 		errMsg = msg["error"]
 	}
 
-	lumber.Debug(`[PULSE :: ACCESS] %v - [%v] %v %v %v - "User-Agent: %s" %s`,
+	lumber.Debug(`[PULSE :: ACCESS] %s - [%s] %s %s %d - "User-Agent: %s" %s`,
 		req.RemoteAddr, req.Proto, req.Method, req.RequestURI,
 		status, req.Header.Get("User-Agent"), errMsg)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -174,7 +174,7 @@ func rest(method, route, data string) ([]byte, error) {
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to %v %v - %v", method, route, err)
+		return nil, fmt.Errorf("Unable to %s %s - %s", method, route, err)
 	}
 	defer res.Body.Close()
 

--- a/api/request.go
+++ b/api/request.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jcelliott/lumber"
 	"github.com/spf13/viper"
 
 	"github.com/nanopack/pulse/influx"
@@ -30,8 +31,9 @@ type (
 func keysRequest(res http.ResponseWriter, req *http.Request) {
 	cols, err := influx.Query("SHOW FIELD KEYS FROM one_day./.*/") // or show measurements? - aggregate
 	if err != nil {
-		// todo: don't panic, we can handle this
-		panic(err)
+		lumber.Error("Failed to get field keys from one_day./.*/ - %s", err.Error())
+		writeBody(apiError{ErrorString: err.Error()}, res, http.StatusInternalServerError, req)
+		return
 	}
 
 	columns := make(map[string]struct{})
@@ -55,7 +57,9 @@ func keysRequest(res http.ResponseWriter, req *http.Request) {
 func tagsRequest(res http.ResponseWriter, req *http.Request) {
 	groupBy, err := influx.Query("SHOW TAG KEYS FROM one_day./.*/")
 	if err != nil {
-		panic(err)
+		lumber.Error("Failed to get tag keys from one_day./.*/ - %s", err.Error())
+		writeBody(apiError{ErrorString: err.Error()}, res, http.StatusInternalServerError, req)
+		return
 	}
 
 	columns := make(map[string]struct{})

--- a/api/request.go
+++ b/api/request.go
@@ -235,7 +235,7 @@ func hourlyStat(res http.ResponseWriter, req *http.Request) {
 
 	// stat is the stat we are selecting
 	stat := req.URL.Query().Get(":stat")
-	query := fmt.Sprintf(`SELECT %s("%v") FROM one_week.aggregate`, verb, stat)
+	query := fmt.Sprintf(`SELECT %s("%s") FROM one_week.aggregate`, verb, stat)
 
 	filters := []string{}
 	for key, val := range req.URL.Query() {
@@ -256,8 +256,8 @@ func hourlyStat(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// set time filter
-	filters = append(filters, fmt.Sprintf("time > now() - %v", start))
-	filters = append(filters, fmt.Sprintf("time < now() - %v", stop))
+	filters = append(filters, fmt.Sprintf("time > now() - %s", start))
+	filters = append(filters, fmt.Sprintf("time < now() - %s", stop))
 
 	// filter by filters
 	if len(filters) > 0 {
@@ -275,7 +275,7 @@ func hourlyStat(res http.ResponseWriter, req *http.Request) {
 			query = fmt.Sprintf("%s GROUP BY time(1h) FILL(0)", query)
 		} else {
 			// else use the number value of backfill
-			query = fmt.Sprintf("%s GROUP BY time(1h) FILL(%v)", query, s)
+			query = fmt.Sprintf("%s GROUP BY time(1h) FILL(%f)", query, s)
 		}
 	}
 
@@ -324,7 +324,7 @@ func dailyStat(res http.ResponseWriter, req *http.Request) {
 
 	// stat is the stat we are selecting
 	stat := req.URL.Query().Get(":stat")
-	query := fmt.Sprintf(`SELECT %s("%v") FROM one_week.aggregate`, verb, stat)
+	query := fmt.Sprintf(`SELECT %s("%s") FROM one_week.aggregate`, verb, stat)
 
 	filters := []string{}
 	for key, val := range req.URL.Query() {
@@ -345,8 +345,8 @@ func dailyStat(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// set time filter
-	filters = append(filters, fmt.Sprintf("time > now() - %v", start))
-	filters = append(filters, fmt.Sprintf("time < now() - %v", stop))
+	filters = append(filters, fmt.Sprintf("time > now() - %s", start))
+	filters = append(filters, fmt.Sprintf("time < now() - %s", stop))
 
 	// filter by filters
 	if len(filters) > 0 {

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -18,7 +18,7 @@ import (
 var clientConn client.Client
 
 func Query(sql string) (*client.Response, error) {
-	lumber.Trace("[PULSE :: INFLUX] Querying influx: '%v'...", sql)
+	lumber.Trace("[PULSE :: INFLUX] Querying influx: '%s'...", sql)
 
 	c, err := influxClient()
 	if err != nil {

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -120,19 +120,22 @@ func KeepContinuousQueriesUpToDate() error {
 		// or do a `show measurements` and skip 'aggregate' or `SHOW MEASUREMENTS WITH MEASUREMENT =~ /([^a][^g][^g][^r][^e][^g][^a][^t][^e]).*/`
 		cols, err := c.Query(client.NewQuery("SHOW FIELD KEYS", "statistics", "s")) // equivalent to including `FROM one_day./.*/`
 		if err != nil {
-			panic(err)
+			// todo: return?
+			lumber.Error("Failed to show field keys from statistics - %s")
 		}
 
 		// check tags
 		groupBy, err := c.Query(client.NewQuery("SHOW TAG KEYS", "statistics", "s"))
 		if err != nil {
-			panic(err)
+			// todo: return?
+			lumber.Error("Failed to show tag keys from statistics - %s")
 		}
 
 		// get continuous queries
 		cont, err := c.Query(client.NewQuery("SHOW CONTINUOUS QUERIES", "statistics", "s"))
 		if err != nil {
-			panic(err)
+			// todo: return?
+			lumber.Error("Failed to show continuous queries from statistics - %s")
 		}
 
 		// get current query
@@ -193,12 +196,12 @@ func KeepContinuousQueriesUpToDate() error {
 			lumber.Trace("[PULSE :: INFLUX] Rebuilding continuous query...")
 			r, err := c.Query(client.NewQuery(`DROP CONTINUOUS QUERY aggregate ON statistics`, "statistics", "s"))
 			if err != nil {
-				fmt.Printf("ERROR: %+v, %+v\n", r, err)
+				lumber.Error("Failed to drop continuous queries - %+v - %+v", r, err)
 			}
-			lumber.Trace("New Query: %+s\n", newQuery)
+			lumber.Trace("New Query: %+s", newQuery)
 			r, err = c.Query(client.NewQuery(newQuery, "statistics", "s"))
 			if err != nil {
-				fmt.Printf("ERROR: %+v, %+v\n", r, err)
+				lumber.Error("Failed to create continuous query - %+v - %+v", r, err)
 			}
 		}
 

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	for _, query := range queries {
 		_, err := influx.Query(query)
 		if err != nil {
-			fmt.Printf("Failed to QUERY/INITIALIZE - '%v' skipping tests\n", err)
+			fmt.Printf("Failed to QUERY/INITIALIZE - '%s' skipping tests\n", err)
 			os.Exit(0)
 		}
 	}

--- a/kapacitor/kapacitor.go
+++ b/kapacitor/kapacitor.go
@@ -53,7 +53,7 @@ func Init() error {
 		InsecureSkipVerify: true, // todo: maybe set back to `viper.GetBool("insecure")`
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to create new client! - %v", err)
+		return fmt.Errorf("Failed to create new client! - %s", err)
 	}
 	_, _, err = cli.Ping()
 	return err
@@ -72,7 +72,7 @@ func SetTask(task Task) error {
 	case "STREAM":
 		Type = client.StreamTask
 	default:
-		return fmt.Errorf("Bad task type - '%v'", task.Type)
+		return fmt.Errorf("Bad task type - '%s'", task.Type)
 	}
 
 	DBRPs[0].Database = task.Database
@@ -88,7 +88,7 @@ func SetTask(task Task) error {
 		// default to disabled
 		Status = client.Disabled
 	default:
-		return fmt.Errorf("Bad task status - '%v'", task.Status)
+		return fmt.Errorf("Bad task status - '%s'", task.Status)
 	}
 
 	var err error
@@ -115,7 +115,7 @@ func SetTask(task Task) error {
 		lumber.Trace("Task Updated")
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to create task - %v", err)
+		return fmt.Errorf("Failed to create task - %s", err)
 	}
 
 	return nil
@@ -125,7 +125,7 @@ func SetTask(task Task) error {
 func DeleteTask(id string) error {
 	err := cli.DeleteTask(cli.TaskLink(id))
 	if err != nil {
-		err = fmt.Errorf("Failed to delete task - %v", err)
+		err = fmt.Errorf("Failed to delete task - %s", err)
 	}
 
 	return err
@@ -176,7 +176,7 @@ func genLambda(alerts map[string]string) string {
 func genWhere(wheres map[string]string) string {
 	w := []string{}
 	for k, v := range wheres {
-		w = append(w, fmt.Sprintf("\"%v\" = '%v'", k, v))
+		w = append(w, fmt.Sprintf("\"%s\" = '%s'", k, v))
 	}
 	return strings.Join(w, " AND ")
 }

--- a/kapacitor/kapacitor_test.go
+++ b/kapacitor/kapacitor_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	viper.SetDefault("kapacitor-address", "http://172.28.128.4:9092")
 	err := kapacitor.Init()
 	if err != nil {
-		fmt.Printf("Failed to init - '%v' skipping tests\n", err)
+		fmt.Printf("Failed to init - '%s' skipping tests\n", err)
 		os.Exit(0)
 	}
 
@@ -48,7 +48,7 @@ func TestCreateUpdateTask(t *testing.T) {
 	}
 	err := kapacitor.SetTask(task)
 	if err != nil {
-		t.Errorf("Failed to add task - %v", err)
+		t.Errorf("Failed to add task - %s", err)
 	}
 
 	// to make work with repo update from 4767348... TO 3003b83...
@@ -56,13 +56,13 @@ func TestCreateUpdateTask(t *testing.T) {
 	task.Status = "disabled"
 	err = kapacitor.SetTask(task)
 	if err != nil {
-		t.Errorf("Failed to update task - %v", err)
+		t.Errorf("Failed to update task - %s", err)
 	}
 
 	task.Status = ""
 	err = kapacitor.SetTask(task)
 	if err != nil {
-		t.Errorf("Failed to test task status blank - %v", err)
+		t.Errorf("Failed to test task status blank - %s", err)
 	}
 
 	task.Status = "bad"
@@ -74,19 +74,19 @@ func TestCreateUpdateTask(t *testing.T) {
 	task.Type = "stream"
 	err = kapacitor.SetTask(task)
 	if err == nil {
-		t.Errorf("Failed to fail add stream task - %v", err)
+		t.Errorf("Failed to fail add stream task - %s", err)
 	}
 
 	task.Type = "bad"
 	err = kapacitor.SetTask(task)
 	if err == nil {
-		t.Errorf("Failed to fail add bad task type - %v", err)
+		t.Errorf("Failed to fail add bad task type - %s", err)
 	}
 }
 
 func TestDeleteTask(t *testing.T) {
 	err := kapacitor.DeleteTask(stat)
 	if err != nil {
-		t.Errorf("Failed to delete task - %v", err)
+		t.Errorf("Failed to delete task - %s", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	// time.Sleep(time.Second)
 
 	if err != nil {
-		panic(fmt.Sprintf("unable to listen %v", err))
+		panic(fmt.Sprintf("unable to listen %s", err))
 	}
 	rtn := m.Run()
 	os.Exit(rtn)
@@ -46,7 +46,7 @@ func TestEndToEnd(test *testing.T) {
 	fmt.Println("Testing end to end...")
 	relay, err := pulse.NewRelay(address, "relay.station.1")
 	if err != nil {
-		test.Errorf("unable to connect to server %v", err)
+		test.Errorf("unable to connect to server %s", err)
 		return
 	}
 	defer relay.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -36,8 +36,10 @@ func TestMain(m *testing.M) {
 	// time.Sleep(time.Second)
 
 	if err != nil {
-		panic(fmt.Sprintf("unable to listen %s", err))
+		fmt.Printf("unable to listen - %s\n", err)
+		return
 	}
+
 	rtn := m.Run()
 	os.Exit(rtn)
 }

--- a/plexer/plex.go
+++ b/plexer/plex.go
@@ -42,22 +42,22 @@ func NewPlexer() *Plexer {
 }
 
 func (plex *Plexer) AddBatcher(name string, observer BatchPublisher) {
-	lumber.Trace("[PULSE :: PLEXER] Add batcher: %v...", name)
+	lumber.Trace("[PULSE :: PLEXER] Add batcher: %s...", name)
 	plex.batch[name] = observer
 }
 
 func (plex *Plexer) RemoveBatcher(name string) {
-	lumber.Trace("[PULSE :: PLEXER] Remove batcher: %v...", name)
+	lumber.Trace("[PULSE :: PLEXER] Remove batcher: %s...", name)
 	delete(plex.batch, name)
 }
 
 func (plex *Plexer) AddObserver(name string, observer SinglePublisher) {
-	lumber.Trace("[PULSE :: PLEXER] Add observer: %v...", name)
+	lumber.Trace("[PULSE :: PLEXER] Add observer: %s...", name)
 	plex.single[name] = observer
 }
 
 func (plex *Plexer) RemoveObserver(name string) {
-	lumber.Trace("[PULSE :: PLEXER] Remove observer: %v...", name)
+	lumber.Trace("[PULSE :: PLEXER] Remove observer: %s...", name)
 	delete(plex.single, name)
 }
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -47,7 +47,7 @@ func main() {
   // register a new client
   relay, err := pulse.NewRelay(address, "lester.tester")
   if err != nil {
-    fmt.Printf("Unable to connect to pulse server %v\n", err)
+    fmt.Printf("Unable to connect to pulse server %s\n", err)
     return
   }
   defer relay.Close()

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -40,6 +40,7 @@ type (
 )
 
 func (relay *Relay) readData() {
+	zero := time.Time{}
 	for {
 		// make a temporary bytes var to read from the connection
 		tmp := make([]byte, 128)
@@ -64,6 +65,8 @@ func (relay *Relay) readData() {
 			}
 		}
 
+		relay.conn.SetReadDeadline(zero)
+
 		// return strings.TrimSuffix(string(data), "\n"), nil
 		datas := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
 		for i := range datas {
@@ -72,9 +75,26 @@ func (relay *Relay) readData() {
 	}
 }
 
+// beat allows the detection and handling of stale tcp connections
+func (relay *Relay) beat() {
+	for {
+		time.Sleep(10 * time.Second)
+		// since we're always reading, lets set a timeout for the pong to come back in 1/2 beat time
+		relay.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		lumber.Trace("[PULSE :: RELAY] PULSE pinging...")
+		_, err := relay.conn.Write([]byte("ping\n"))
+		if err != nil {
+			lumber.Trace("[PULSE :: RELAY] PULSE ping failed - %s", err)
+			relay.errChan <- err
+			return
+		}
+		lumber.Trace("[PULSE :: RELAY] PULSE pinged!")
+	}
+}
+
 // establishConnection establishes a connection and id's with the server
 func (relay *Relay) establishConnection() error {
-	conn, err := net.Dial("tcp", relay.hostAddr)
+	conn, err := net.DialTimeout("tcp", relay.hostAddr, 10*time.Second)
 	if err != nil {
 		return err
 	}
@@ -90,6 +110,9 @@ func (relay *Relay) establishConnection() error {
 
 	// start data reader
 	go relay.readData()
+
+	// start heartbeat
+	go relay.beat()
 
 	var line string
 
@@ -134,14 +157,15 @@ func (relay *Relay) runLoop() {
 	for {
 		select {
 		case err := <-relay.errChan:
-			lumber.Error("[PULSE :: RELAY] Disconnected from host %v!", relay.hostAddr)
+			lumber.Error("[PULSE :: RELAY] Disconnected from host %s!", relay.hostAddr)
+			relay.conn.Close()
 			// retry indefinitely
 			for {
 				if err = relay.establishConnection(); err == nil {
-					lumber.Info("[PULSE :: RELAY] Reconnected to host %v!", relay.hostAddr)
+					lumber.Info("[PULSE :: RELAY] Reconnected to host %s!", relay.hostAddr)
 					break
 				}
-				lumber.Debug("[PULSE :: RELAY] Reconnecting to host %v...  Fail!", relay.hostAddr)
+				lumber.Debug("[PULSE :: RELAY] Reconnecting to host %s...  Fail!", relay.hostAddr)
 				<-time.After(5 * time.Second)
 			}
 			// we won't have anything in 'line' so continue
@@ -155,6 +179,8 @@ func (relay *Relay) runLoop() {
 			case "ok":
 				lumber.Trace("[PULSE :: RELAY] OK: %v", split)
 				// just an ack
+			case "pong":
+				lumber.Trace("[PULSE :: RELAY] PONG: %v", split)
 			case "get":
 				if len(split) != 2 {
 					continue
@@ -165,6 +191,7 @@ func (relay *Relay) runLoop() {
 				for _, stat := range stats {
 					tagCollector, ok := relay.collectors[stat]
 					if !ok {
+						lumber.Trace("[PULSE :: RELAY] stat %s !ok", stat)
 						continue
 					}
 					for name, value := range tagCollector.collector.Collect() {
@@ -177,11 +204,14 @@ func (relay *Relay) runLoop() {
 				}
 				if len(results) > 0 {
 					response := fmt.Sprintf("got %s\n", strings.Join(results, ","))
-					relay.conn.Write([]byte(response))
+					_, err := relay.conn.Write([]byte(response))
+					if err != nil {
+						lumber.Trace("[PULSE :: RELAY] GET response write error - %s", err)
+					}
 				}
 			default:
 				lumber.Trace("[PULSE :: RELAY] BAD: %v", split)
-				relay.conn.Write([]byte("unknown command\n"))
+				// causes network spam if we write anything to connection
 			}
 		}
 	}
@@ -218,7 +248,7 @@ func (relay *Relay) AddCollector(name string, tags []string, collector Collector
 		return DuplicateCollector
 	}
 	if _, err := relay.conn.Write([]byte(fmt.Sprintf("add %s:%s\n", name, strings.Join(tags, ",")))); err != nil {
-		lumber.Trace("[PULSE :: RELAY] Failed to write!")
+		lumber.Trace("[PULSE :: RELAY] Failed to add collector to server - %s", err)
 		return err
 	}
 
@@ -235,7 +265,9 @@ func (relay *Relay) RemoveCollector(name string) {
 		// todo: lock
 		delete(relay.collectors, name)
 		lumber.Trace("[PULSE :: RELAY] Removed '%s' as collector.", name)
-		relay.conn.Write([]byte(fmt.Sprintf("remove %v\n", name)))
+		if _, err := relay.conn.Write([]byte(fmt.Sprintf("remove %s\n", name))); err != nil {
+			lumber.Trace("[PULSE :: RELAY] Failed to remove collector from server - %s", err)
+		}
 	}
 }
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -178,12 +178,12 @@ func (relay *Relay) runLoop() {
 			cmd := split[0]
 			switch cmd {
 			case "ok":
-				lumber.Trace("[PULSE :: RELAY] OK: %v", split)
+				lumber.Trace("[PULSE :: RELAY] OK: %s", split)
 				// just an ack
 			case "pong":
-				lumber.Trace("[PULSE :: RELAY] PONG: %v", split)
+				lumber.Trace("[PULSE :: RELAY] PONG: %s", split)
 			case "beat":
-				lumber.Trace("[PULSE :: RELAY] BEAT: %v", split)
+				lumber.Trace("[PULSE :: RELAY] BEAT: %s", split)
 				if len(split) != 2 {
 					continue
 				}
@@ -195,7 +195,7 @@ func (relay *Relay) runLoop() {
 				if len(split) != 2 {
 					continue
 				}
-				lumber.Trace("[PULSE :: RELAY] GET: %v", split)
+				lumber.Trace("[PULSE :: RELAY] GET: %s", split)
 				stats := strings.Split(split[1], ",")
 				results := make([]string, 0)
 				for _, stat := range stats {
@@ -220,7 +220,7 @@ func (relay *Relay) runLoop() {
 					}
 				}
 			default:
-				lumber.Trace("[PULSE :: RELAY] BAD: %v", split)
+				lumber.Trace("[PULSE :: RELAY] BAD: %s", split)
 				// causes network spam if we write anything to connection
 			}
 		}

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -30,13 +30,13 @@ func stdoutPublisher(messages plexer.MessageSet) error {
 			tags[elems[0]] = elems[1]
 		}
 
-		fmt.Printf("BATCH : %s, %v, %v\n", message.ID, tags, message.Data)
+		fmt.Printf("BATCH : %s, %v, %s\n", message.ID, tags, message.Data)
 	}
 
 	// immitation single
 	for _, message := range messages.Messages {
 		message.Tags = append(message.Tags, messages.Tags...)
-		fmt.Printf("SINGLE: %+q, %v\n", append(message.Tags, message.ID), message.Data)
+		fmt.Printf("SINGLE: %+q, %s\n", append(message.Tags, message.ID), message.Data)
 	}
 
 	return nil

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -30,7 +30,7 @@ func stdoutPublisher(messages plexer.MessageSet) error {
 			tags[elems[0]] = elems[1]
 		}
 
-		fmt.Printf("BATCH : %s, %v, %s\n", message.ID, tags, message.Data)
+		fmt.Printf("BATCH : %s, %s, %s\n", message.ID, tags, message.Data)
 	}
 
 	// immitation single

--- a/server/server.go
+++ b/server/server.go
@@ -46,9 +46,9 @@ func Listen(address string, publisher Publisher) error {
 			conn, err := serverSocket.Accept()
 			if err != nil {
 				// if the connection stops working we should
-				// panic so we never are in a state where we thing
-				// its accepting and it isnt
-				panic(err)
+				// return so we never are in a state where we think
+				// it's accepting and it isnt
+				lumber.Error("Failed to accept TCP connection - %s", err.Error())
 			}
 
 			// handle each connection individually (non-blocking)
@@ -151,17 +151,17 @@ func handleConnection(conn net.Conn) {
 
 			split := strings.SplitN(line, " ", 2)
 			if len(split) != 2 {
-				lumber.Trace("[PULSE :: SERVER] Not enough data: %v", split)
+				lumber.Trace("[PULSE :: SERVER] Not enough data: %s", split)
 				continue
 			}
 
 			cmd := split[0]
 			switch cmd {
 			case "ok":
-				lumber.Trace("[PULSE :: SERVER] OK: %v", split)
+				lumber.Trace("[PULSE :: SERVER] OK: %s", split)
 				// just an ack
 			case "got":
-				lumber.Trace("[PULSE :: SERVER] GOT: %v", split)
+				lumber.Trace("[PULSE :: SERVER] GOT: %s", split)
 				stats := strings.Split(split[1], ",")
 
 				metric := plexer.MessageSet{
@@ -195,7 +195,7 @@ func handleConnection(conn net.Conn) {
 				}
 				publish(metric)
 			case "add":
-				lumber.Trace("[PULSE :: SERVER] ADD: %v", split)
+				lumber.Trace("[PULSE :: SERVER] ADD: %s", split)
 				if !strings.Contains(split[1], ":") {
 					clients[id].add(split[1], []string{})
 					continue
@@ -208,15 +208,15 @@ func handleConnection(conn net.Conn) {
 				clients[id].add(split[0], tags)
 
 			case "remove":
-				lumber.Trace("[PULSE :: SERVER] REMOVE: %v", split)
+				lumber.Trace("[PULSE :: SERVER] REMOVE: %s", split)
 				clients[id].remove(split[1])
 				// record that the remote does not have a stat available
 			case "close":
-				lumber.Trace("[PULSE :: SERVER] CLOSE: %v", split)
+				lumber.Trace("[PULSE :: SERVER] CLOSE: %s", split)
 				// clean shutoff of the connection
 				return
 			default:
-				lumber.Trace("[PULSE :: SERVER] BAD: %v", split)
+				lumber.Trace("[PULSE :: SERVER] BAD: %s", split)
 				// don't spam network
 			}
 		case err := <-errChan:

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,13 +30,13 @@ func stdoutPublisher(messages plexer.MessageSet) error {
 			tags[elems[0]] = elems[1]
 		}
 
-		fmt.Printf("BATCH : %s, %v, %v\n", message.ID, tags, message.Data)
+		fmt.Printf("BATCH : %s, %v, %s\n", message.ID, tags, message.Data)
 	}
 
 	// immitation single
 	for _, message := range messages.Messages {
 		message.Tags = append(message.Tags, messages.Tags...)
-		fmt.Printf("SINGLE: %+q, %v\n", append(message.Tags, message.ID), message.Data)
+		fmt.Printf("SINGLE: %+q, %s\n", append(message.Tags, message.ID), message.Data)
 	}
 
 	return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,7 +30,7 @@ func stdoutPublisher(messages plexer.MessageSet) error {
 			tags[elems[0]] = elems[1]
 		}
 
-		fmt.Printf("BATCH : %s, %v, %s\n", message.ID, tags, message.Data)
+		fmt.Printf("BATCH : %s, %s, %s\n", message.ID, tags, message.Data)
 	}
 
 	// immitation single


### PR DESCRIPTION
We need to wait to publish this version of pulse until we have a good upgrade solution to upgrade our services to the newest automatically. This relies on an updated nanoagent(pulse client) to work properly and visa/versa.